### PR TITLE
Fix how to import Shortcuts

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ class Shortcuts {
 This is how you'd use the library:
 
 ```ts
-import {Shortcuts} from 'shortcuts';
+import Shortcuts from 'shortcuts';
 
 // Let's create a new shortcuts manager instance
 


### PR DESCRIPTION
It looks like `Shortcuts` is the default export.